### PR TITLE
Url structure

### DIFF
--- a/hearthstonearenastats/app/account/urls.py
+++ b/hearthstonearenastats/app/account/urls.py
@@ -5,5 +5,6 @@ from hearthstonearenastats.app.account import views as account_views
 
 urlpatterns = patterns(
     '',
-    url(r'^home/$', account_views.ProfileMainPage.as_view()),
+    url(r'^home/$', account_views.ProfileMainPage.as_view(), name='home'),
+    url(r'^profile/$', account_views.ProfileEdit.as_view(), name='profile'),
 )

--- a/hearthstonearenastats/app/account/views.py
+++ b/hearthstonearenastats/app/account/views.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse_lazy
 from django.views.generic import TemplateView
 from braces.views import LoginRequiredMixin
 
@@ -5,7 +6,16 @@ from braces.views import LoginRequiredMixin
 class ProfileMainPage(LoginRequiredMixin, TemplateView):
     template_name = 'account/home.html'
 
-    login_url = '/account/login/'
+    login_url = reverse_lazy('login')
+
+    def get_context_data(self):
+        pass
+
+
+class ProfileEdit(LoginRequiredMixin, TemplateView):
+    template_name = 'account/profile.html'
+
+    login_url = reverse_lazy('login')
 
     def get_context_data(self):
         pass

--- a/hearthstonearenastats/settings/base.py
+++ b/hearthstonearenastats/settings/base.py
@@ -47,5 +47,5 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-LOGIN_URL = '/account/login/'
+LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/account/profile'

--- a/hearthstonearenastats/urls.py
+++ b/hearthstonearenastats/urls.py
@@ -7,15 +7,12 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^$',
-        TemplateView.as_view(template_name='index.html')),
-    url(r'^admin/',
-        include(admin.site.urls)),
-    url(r'^account/login/',
-        'django.contrib.auth.views.login'),
-    url(r'^account/logout/',
-        'django.contrib.auth.views.logout',
-        {'next_page': '/'}),
+    url(r'^$', TemplateView.as_view(template_name='index.html')),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^login/', 'django.contrib.auth.views.login', name='login'),
+    url(r'^logout/', 'django.contrib.auth.views.logout', 
+        {'next_page': '/'}, name='logout'),
+
     url(r'^account/',
         include('hearthstonearenastats.app.account.urls',
                 namespace='account')),

--- a/hearthstonearenastats/urls.py
+++ b/hearthstonearenastats/urls.py
@@ -16,6 +16,4 @@ urlpatterns = patterns(
     url(r'^account/',
         include('hearthstonearenastats.app.account.urls',
                 namespace='account')),
-    url(r'^account/profile/',
-        TemplateView.as_view(template_name='account/profile.html'))
 )

--- a/hearthstonearenastats/urls.py
+++ b/hearthstonearenastats/urls.py
@@ -10,7 +10,7 @@ urlpatterns = patterns(
     url(r'^$', TemplateView.as_view(template_name='index.html')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^login/', 'django.contrib.auth.views.login', name='login'),
-    url(r'^logout/', 'django.contrib.auth.views.logout', 
+    url(r'^logout/', 'django.contrib.auth.views.logout',
         {'next_page': '/'}, name='logout'),
 
     url(r'^account/',

--- a/templates/base-sidebar.html
+++ b/templates/base-sidebar.html
@@ -29,7 +29,7 @@
       <li class="pure-menu-heading">Stats</li>
       <li><a href="#">Arena Stats</a></li>
       <li class="pure-menu-heading">Account Preferences</li>
-      <li><a href="#">Profile</a></li>
+      <li><a href="{% url 'account:profile' %}">Profile</a></li>
       <li><a href="{% url 'logout' %}">Log Out</a></li>
       {% endblock %}
     </ul>

--- a/templates/base-sidebar.html
+++ b/templates/base-sidebar.html
@@ -30,7 +30,7 @@
       <li><a href="#">Arena Stats</a></li>
       <li class="pure-menu-heading">Account Preferences</li>
       <li><a href="#">Profile</a></li>
-      <li><a href="/account/logout">Log Out</a></li>
+      <li><a href="{% url 'logout' %}">Log Out</a></li>
       {% endblock %}
     </ul>
   </div>

--- a/templates/base-topbar.html
+++ b/templates/base-topbar.html
@@ -18,7 +18,7 @@
       <li><a href="#">About</a></li>
 
       {% if user.is_authenticated %}
-      <!-- <li><a href="{% url 'account:home' %}">Account Page</a></li> -->
+      <li><a href="{% url 'account:home' %}">Account Page</a></li>
       <li><a href="{% url 'logout' %}">Log Out</a></li>
       {% else %}
       <li><a href="{% url 'login' %}">Login</a></li>

--- a/templates/base-topbar.html
+++ b/templates/base-topbar.html
@@ -16,13 +16,14 @@
     <ul>
       {% block menu-links %}
       <li><a href="#">About</a></li>
-      <li>
-        {% if user.is_authenticated %}
-        <a href="/account/logout">Log Out</a>
-        {% else %}
-        <a href="/account/login">Login</a>
-        {% endif %}
-      </li>
+
+      {% if user.is_authenticated %}
+      <!-- <li><a href="{% url 'account:home' %}">Account Page</a></li> -->
+      <li><a href="{% url 'logout' %}">Log Out</a></li>
+      {% else %}
+      <li><a href="{% url 'login' %}">Login</a></li>
+      {% endif %}
+
       {% endblock %}
     </ul>
   </div>


### PR DESCRIPTION
Here we remove all the hardcoding of urls, and put them into a nicer structure.

Removing the hardcoding means good use of `{% url %}` template tags, use of `django.core.urlresolvers.reverse_lazy` in login_required views.

Improving the structure means that login and logout now live at '/login/' and '/logout/', and that all the account info now live under the account app urlconfig, and are added to the root urlconfig through an include.
